### PR TITLE
Fix exception syntax according to PEP-3110

### DIFF
--- a/microbe_census/microbe_census.py
+++ b/microbe_census/microbe_census.py
@@ -351,7 +351,7 @@ def process_seqfile(args, paths):
 					if args['filter_dups']: seqs.add(str(rec.seq))
 					if read_id == args['nreads']: break
 			if read_id == args['nreads']: break
-		except Exception, e:
+		except Exception as e:
 			error = "\nThe following error was encountered when parsing sequence #%s in the input file:\n%s\n" % (i+1, e)
 			clean_up(paths)
 			sys.exit(error)


### PR DESCRIPTION
According to PEP-3110 (https://www.python.org/dev/peps/pep-3110/), exceptions should be assigned to a variable using the keyword "as", instead of using the comma syntax, which is only valid in Python versions prior to 2.6 (i.e. 2.5 and below).